### PR TITLE
V1.0.0 prep

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,7 @@
     <!-- Copy the mod to the game directory -->
     <GameModDir Condition="'$(GameModDir)' == ''">$(GameDir)/Mods/$(AssemblyName)</GameModDir>
     <OutDir Condition="'$(Configuration)' == 'Debug'">$(GameModDir)/</OutDir>
+    <VersionTimestamp>$([System.DateTime]::UtcNow.ToString(`o`))</VersionTimestamp>
   </PropertyGroup>
 
   <!-- Replace the default version if something was set for it -->
@@ -30,7 +31,7 @@
   <!-- Publish the mod as a neat zip file -->
   <Target Name="PrepareForPublishing" AfterTargets="AfterBuild" Condition="'$(Configuration)' == 'Release'">
     <!-- Replace $(AssemblyVersion) with the actual version -->
-    <Exec Command="powershell -Command &quot;(Get-Content '$(OutputPath)Definition.json') -replace '\$\(AssemblyVersion\)', '$(AssemblyVersion)' | Set-Content '$(OutputPath)Definition.json'&quot;" />
+    <Exec Command="powershell -Command &quot;(Get-Content '$(OutputPath)Definition.json') -replace '\$\(AssemblyVersion\)', '$(AssemblyVersion)_$(VersionTimestamp)' | Set-Content '$(OutputPath)Definition.json'&quot;" />
 
     <PropertyGroup>
       <ModsDirectory>$(OutputPath)/Mods</ModsDirectory>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Try to find the directory on our own -->
     <GameManagedDir Condition="'$(GameManagedDir)' == ''">$([System.IO.Directory]::GetDirectories(`$(GameDir)`, `*_Data`)[0])\Managed</GameManagedDir>
-    
+
     <!-- Copy the mod to the game directory -->
     <GameModDir Condition="'$(GameModDir)' == ''">$(GameDir)/Mods/$(AssemblyName)</GameModDir>
     <OutDir Condition="'$(Configuration)' == 'Debug'">$(GameModDir)/</OutDir>
@@ -11,9 +11,9 @@
 
   <!-- Replace the default version if something was set for it -->
   <PropertyGroup Condition="'$(AssemblyVersion)' == '' OR '$(MajorVersion)' != '' OR '$(MinorVersion)' != ''">
-    <MajorVersion Condition="'$(MajorVersion)' == ''">0</MajorVersion>
-    <MinorVersion Condition="'$(MinorVersion)' == ''">1</MinorVersion>
-    <PatchVersion Condition="'$(PatchVersion)' == ''">8</PatchVersion>
+    <MajorVersion Condition="'$(MajorVersion)' == ''">1</MajorVersion>
+    <MinorVersion Condition="'$(MinorVersion)' == ''">0</MinorVersion>
+    <PatchVersion Condition="'$(PatchVersion)' == ''">0</PatchVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <ProductVersion>$(AssemblyVersion)</ProductVersion>
@@ -44,15 +44,15 @@
 
     <!-- Assure the output path exists -->
     <MakeDir Directories="$(PublishPath)" />
-    
+
     <!-- Remove the old Mods directory, and Zips file if any is lying around -->
     <ItemGroup>
       <OldZips Include="$(PublishPath)/$(AssemblyName)_*.zip" />
     </ItemGroup>
-    
+
     <RemoveDir Directories="$(ModsDirectory)"  ContinueOnError="true" />
     <Delete Files="@(OldZips)" />
-    
+
     <!-- Create the Mods directory again -->
     <MakeDir Directories="$(ModDirectory)" />
 
@@ -65,7 +65,7 @@
 
     <!-- Zip it up -->
     <Exec Command="powershell -Command &quot;Compress-Archive -Path '$(ModsDirectory)' -Destination '$(ZipName)'&quot;" />
-    
+
     <!-- Move them to the game directory -->
     <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(GameModDir)" />
   </Target>

--- a/TweaksAndThings/Patches/AutoHotboxSpotter_SpotterLoop_Patch.cs
+++ b/TweaksAndThings/Patches/AutoHotboxSpotter_SpotterLoop_Patch.cs
@@ -18,9 +18,10 @@ internal class AutoHotboxSpotter_SpotterLoop_Patch
     {
         TweaksAndThingsPlugin tweaksAndThings = SingletonPluginBase<TweaksAndThingsPlugin>.Shared;
         if (!tweaksAndThings.IsEnabled) return true;
-        bool buttonsHaveCost = tweaksAndThings?.settings?.EndGearHelpersRequirePayment ?? false;
+        bool buttonsHaveCost = tweaksAndThings.EndGearHelpersRequirePayment();
+        bool cabooseRequired = tweaksAndThings.RequireConsistCabooseForOilerAndHotboxSpotter();
 
-        if (buttonsHaveCost) __result = __instance.MrocAutoHotboxSpotterLoop(_log);
+        if (buttonsHaveCost) __result = __instance.MrocAutoHotboxSpotterLoop(_log, cabooseRequired);
         return !buttonsHaveCost; //only hit this if !buttonsHaveCost, since Loop is a coroutine
     }
 }

--- a/TweaksAndThings/Patches/AutoOiler_Loop_Patch.cs
+++ b/TweaksAndThings/Patches/AutoOiler_Loop_Patch.cs
@@ -18,9 +18,10 @@ internal class AutoOiler_Loop_Patch
     {
         TweaksAndThingsPlugin tweaksAndThings = SingletonPluginBase<TweaksAndThingsPlugin>.Shared;
         if (!tweaksAndThings.IsEnabled) return true;
-        bool buttonsHaveCost = tweaksAndThings?.settings?.EndGearHelpersRequirePayment ?? false;
+        bool buttonsHaveCost = tweaksAndThings.EndGearHelpersRequirePayment();
+        bool cabooseRequired = tweaksAndThings.RequireConsistCabooseForOilerAndHotboxSpotter();
 
-        if (buttonsHaveCost)__result = __instance.MrocAutoOilerLoop(_log);
+        if (buttonsHaveCost) __result = __instance.MrocAutoOilerLoop(_log, cabooseRequired);
         return !buttonsHaveCost; //only hit this if !buttonsHaveCost, since Loop is a coroutine
     }
 }

--- a/TweaksAndThings/Patches/CarPickable_HandleShowContextMenu_Patch.cs
+++ b/TweaksAndThings/Patches/CarPickable_HandleShowContextMenu_Patch.cs
@@ -7,7 +7,6 @@ using RollingStock;
 using System.Linq;
 using UI;
 using UI.ContextMenu;
-using static Model.Car;
 
 namespace RMROC451.TweaksAndThings.Patches;
 
@@ -21,15 +20,14 @@ internal class CarPickable_HandleShowContextMenu_Patch
         TweaksAndThingsPlugin tweaksAndThings = SingletonPluginBase<TweaksAndThingsPlugin>.Shared;
         if (!tweaksAndThings.IsEnabled) return;
 
-        bool buttonsHaveCost = tweaksAndThings?.settings?.EndGearHelpersRequirePayment ?? false;
+        bool buttonsHaveCost = tweaksAndThings.EndGearHelpersRequirePayment();
         ContextMenu shared = ContextMenu.Shared;
-        var consist = car.EnumerateCoupled(LogicalEnd.A);
-        shared.AddButton(ContextMenuQuadrant.Unused2, $"{(consist.Any(c => c.HandbrakeApplied()) ? "Release " : "Set ")} Consist", SpriteName.Handbrake, delegate
+        shared.AddButton(ContextMenuQuadrant.Unused2, $"{(car._set.Cars.Any(c => c.HandbrakeApplied()) ? "Release " : "Set ")} Consist", SpriteName.Handbrake, delegate
         {
             CarInspector_PopulateCarPanel_Patch.MrocConsistHelper(car, MrocHelperType.Handbrake, buttonsHaveCost);
         });
 
-        if (consist.Any(c => c.EndAirSystemIssue()))
+        if (car._set.Cars.Any(c => c.EndAirSystemIssue()))
         {
             shared.AddButton(ContextMenuQuadrant.Unused2, $"Air Up Consist", SpriteName.Select, delegate
             {
@@ -37,7 +35,7 @@ internal class CarPickable_HandleShowContextMenu_Patch
             });
         }
 
-        if (consist.Any(c => c.SupportsBleed()))
+        if (car._set.Cars.Any(c => c.SupportsBleed()))
         {
             shared.AddButton(ContextMenuQuadrant.Unused2, $"Bleed Consist", SpriteName.Bleed, delegate
             {

--- a/TweaksAndThings/Patches/CarPickable_HandleShowContextMenu_Patch.cs
+++ b/TweaksAndThings/Patches/CarPickable_HandleShowContextMenu_Patch.cs
@@ -45,6 +45,11 @@ internal class CarPickable_HandleShowContextMenu_Patch
             });
         }
 
+        shared.AddButton(ContextMenuQuadrant.Unused2, $"Follow", SpriteName.Inspect, delegate
+        {
+            CameraSelector.shared.FollowCar(car);
+        });
+
         shared.BuildItemAngles();
         shared.StartCoroutine(shared.AnimateButtonsShown());
     }

--- a/TweaksAndThings/Patches/TagController_UpdateTag_Patch.cs
+++ b/TweaksAndThings/Patches/TagController_UpdateTag_Patch.cs
@@ -3,6 +3,8 @@ using Model;
 using Model.OpsNew;
 using Railloader;
 using RMROC451.TweaksAndThings.Extensions;
+using System.Collections.Generic;
+using System.Linq;
 using UI.Tags;
 
 namespace RMROC451.TweaksAndThings.Patches;
@@ -32,13 +34,16 @@ internal class TagController_UpdateTag_Patch
     private static void ProceedWithPostFix(Car car, TagCallout tagCallout)
     {
         tagCallout.callout.Title = string.Format(tagTitleFormat, "{0}", car.DisplayName);
+        List<string> tags = [];
+
+        if (car.HasHotbox) tags.Add(TextSprites.Hotbox);
+        if (car.EndAirSystemIssue()) tags.Add(TextSprites.CycleWaybills);
+        if (car.HandbrakeApplied()) tags.Add(TextSprites.HandbrakeWheel);
 
         tagCallout.callout.Title =
-            (car.CarAndEndGearIssue(), car.EndAirSystemIssue(), car.HandbrakeApplied()) switch
+            tags.Any() switch
             {
-                (true, _, _) => $"{tagCallout.callout.Title}{tagTitleAndIconDelimeter}{TextSprites.CycleWaybills}{TextSprites.HandbrakeWheel}".Replace("{0}", "2"),
-                (_, true, _) => $"{tagCallout.callout.Title}{tagTitleAndIconDelimeter}{TextSprites.CycleWaybills}".Replace("{0}", "1"),
-                (_, _, true) => $"{tagCallout.callout.Title}{tagTitleAndIconDelimeter}{TextSprites.HandbrakeWheel}".Replace("{0}", "1"),
+                true => $"{tagCallout.callout.Title}{tagTitleAndIconDelimeter}{string.Join("", tags)}".Replace("{0}", tags.Count().ToString()),
                 _ => car.DisplayName
             };
     }

--- a/TweaksAndThings/Settings/Settings.cs
+++ b/TweaksAndThings/Settings/Settings.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using RMROC451.TweaksAndThings.Enums;
+using UI.Builder;
+using Model;
+using RMROC451.TweaksAndThings.Extensions;
 
 namespace RMROC451.TweaksAndThings;
 
@@ -18,19 +21,26 @@ public class Settings
         List<WebhookSettings> webhookSettingsList,
         bool handBrakeAndAirTagModifiers,
         RosterFuelColumnSettings engineRosterFuelColumnSettings,
-        bool endGearHelpersRequirePayment
+        bool endGearHelpersRequirePayment,
+        bool requireConsistCabooseForOilerAndHotboxSpotter,
+        bool cabooseAllowsConsistInfo
     )
     {
         WebhookSettingsList = webhookSettingsList;
         HandBrakeAndAirTagModifiers = handBrakeAndAirTagModifiers;
         EngineRosterFuelColumnSettings = engineRosterFuelColumnSettings;
         EndGearHelpersRequirePayment = endGearHelpersRequirePayment;
+        RequireConsistCabooseForOilerAndHotboxSpotter = requireConsistCabooseForOilerAndHotboxSpotter;
+        CabooseAllowsConsistInfo = cabooseAllowsConsistInfo;
     }
 
+    public readonly UIState<string> _selectedTabState = new UIState<string>(null);
     public List<WebhookSettings>? WebhookSettingsList;
     public bool HandBrakeAndAirTagModifiers;
     public RosterFuelColumnSettings? EngineRosterFuelColumnSettings;
     public bool EndGearHelpersRequirePayment;
+    public bool RequireConsistCabooseForOilerAndHotboxSpotter;
+    public bool CabooseAllowsConsistInfo;
 
     internal void AddAnotherRow()
     {
@@ -82,15 +92,21 @@ public static class SettingsExtensions
 {
     public static List<WebhookSettings> SanitizeEmptySettings(this IEnumerable<WebhookSettings>? settings)
     {
-        List<WebhookSettings> output = 
-            settings?.Where(s => !string.IsNullOrEmpty(s.WebhookUrl))?.ToList() ?? 
+        List<WebhookSettings> output =
+            settings?.Where(s => !string.IsNullOrEmpty(s.WebhookUrl))?.ToList() ??
             new();
 
         output.Add(new());
 
         return output;
     }
-        
+
+    public static bool CabooseAllowsConsistInfo(this TweaksAndThingsPlugin input) =>
+        input?.settings?.CabooseAllowsConsistInfo ?? false;
+    public static bool EndGearHelpersRequirePayment(this TweaksAndThingsPlugin input) =>
+        input?.settings?.EndGearHelpersRequirePayment ?? false;
+    public static bool RequireConsistCabooseForOilerAndHotboxSpotter(this TweaksAndThingsPlugin input) =>
+        input?.settings?.RequireConsistCabooseForOilerAndHotboxSpotter ?? false;
     public static bool CabooseNonMotiveAllowedSetting(this TweaksAndThingsPlugin input, Car car) =>
         input.EndGearHelpersRequirePayment() && car.set.Cars.CabooseInConsist() && car.NotMotivePower();
 

--- a/TweaksAndThings/Settings/Settings.cs
+++ b/TweaksAndThings/Settings/Settings.cs
@@ -91,4 +91,7 @@ public static class SettingsExtensions
         return output;
     }
         
+    public static bool CabooseNonMotiveAllowedSetting(this TweaksAndThingsPlugin input, Car car) =>
+        input.EndGearHelpersRequirePayment() && car.set.Cars.CabooseInConsist() && car.NotMotivePower();
+
 }

--- a/TweaksAndThings/TweaksAndThingsPlugin.cs
+++ b/TweaksAndThings/TweaksAndThingsPlugin.cs
@@ -82,16 +82,73 @@ public class TweaksAndThingsPlugin : SingletonPluginBase<TweaksAndThingsPlugin>,
         settings.WebhookSettingsList =
             settings?.WebhookSettingsList.SanitizeEmptySettings();
 
-        //WebhookUISection(ref builder);
-        //builder.AddExpandingVerticalSpacer();
-        WebhooksListUISection(ref builder);
-        builder.AddExpandingVerticalSpacer();
-        HandbrakesAndAnglecocksUISection(ref builder);
-        builder.AddExpandingVerticalSpacer();
-        EnginRosterShowsFuelStatusUISection(ref builder);
+        builder.AddTabbedPanels(settings._selectedTabState, delegate (UITabbedPanelBuilder tabBuilder)
+        {
+            tabBuilder.AddTab("Caboose Mods", "cabooseUpdates", CabooseMods);
+            tabBuilder.AddTab("UI", "rosterUi", UiUpdates);
+            tabBuilder.AddTab("Webhooks", "webhooks", WebhooksListUISection);
+        });
     }
 
-    private void EnginRosterShowsFuelStatusUISection(ref UIPanelBuilder builder)
+    private void CabooseMods(UIPanelBuilder builder)
+    {
+        builder.AddField(
+            "Caboose Use",
+            builder.AddToggle(
+                () => settings?.EndGearHelpersRequirePayment ?? false,
+                delegate (bool enabled)
+                {
+                    if (settings == null) settings = new();
+                    settings.EndGearHelpersRequirePayment = enabled;
+                    builder.Rebuild();
+                }
+            )
+        ).Tooltip("Enable End Gear Helper Cost", @$"Will cost 1 minute of AI Brake Crew & Caboose Crew time per car in the consist when the new inspector buttons are utilized.
+
+1.5x multiplier penalty to AI Brake Crew cost if no sufficiently crewed caboose nearby.
+
+Caboose starts reloading `Crew Hours` at any Team or Repair track (no waybill), after being stationary for 30 seconds.
+
+AutoOiler Update: Increases limit that crew will oiling a car from 75% -> 99%, also halves the time it takes (simulating crew from lead end and caboose handling half the train)
+
+AutoHotboxSpotter Update: decrease the random wait from 30 - 300 seconds to 15 - 30 seconds (Safety Is Everyone's Job)");
+
+        builder.AddField(
+            $"AutoAI\nRequirement",
+            builder.AddToggle(
+                () => settings?.RequireConsistCabooseForOilerAndHotboxSpotter ?? false,
+                delegate (bool enabled)
+                {
+                    if (settings == null) settings = new();
+                    settings.RequireConsistCabooseForOilerAndHotboxSpotter = enabled;
+                    builder.Rebuild();
+                }
+            )
+        ).Tooltip("AI Engineer Requires Caboose", $@"A caboose is required in the consist to check for Hotboxes and perform Auto Oiler, if checked.");
+    }
+
+    private void UiUpdates(UIPanelBuilder builder)
+    {
+        builder.AddField(
+            "Enable Tag Updates",
+            builder.AddToggle(
+                () => settings?.HandBrakeAndAirTagModifiers ?? false,
+                delegate (bool enabled)
+                {
+                    if (settings == null) settings = new();
+                    settings.HandBrakeAndAirTagModifiers = enabled;
+                    builder.Rebuild();
+                }
+            )
+        ).Tooltip("Enable Tag Updates", $@"Will suffix tag title with:
+{TextSprites.CycleWaybills} if Air System issue.
+{TextSprites.HandbrakeWheel} if there is a handbrake set.
+{TextSprites.Hotbox} if a hotbox.");
+
+        EngineRosterShowsFuelStatusUISection(builder);
+    }
+
+    private void EngineRosterShowsFuelStatusUISection(UIPanelBuilder builder)
     {
         var columns = Enum.GetValues(typeof(EngineRosterFuelDisplayColumn)).Cast<EngineRosterFuelDisplayColumn>().Select(i => i.ToString()).ToList();
         builder.AddSection("Fuel Display in Engine Roster", delegate (UIPanelBuilder builder)
@@ -123,39 +180,7 @@ public class TweaksAndThingsPlugin : SingletonPluginBase<TweaksAndThingsPlugin>,
         });
     }
 
-    private void HandbrakesAndAnglecocksUISection(ref UIPanelBuilder builder)
-    {
-        builder.AddSection("Tag Callout Handbrake and Air System Helper", delegate (UIPanelBuilder builder)
-        {
-            builder.AddField(
-                "Enable Tag Updates",
-                builder.AddToggle(
-                    () => settings?.HandBrakeAndAirTagModifiers ?? false,
-                    delegate (bool enabled)
-                    {
-                        if (settings == null) settings = new();
-                        settings.HandBrakeAndAirTagModifiers = enabled;
-                        builder.Rebuild();
-                    }
-                )
-            ).Tooltip("Enable Tag Updates", $"Will add {TextSprites.CycleWaybills} to the car tag title having Air System issues. Also prepends {TextSprites.HandbrakeWheel} if there is a handbrake set.\n\nHolding Left Alt while tags are displayed only shows tag titles that have issues.");
-
-            builder.AddField(
-                "Caboose Use",
-                builder.AddToggle(
-                    () => settings?.EndGearHelpersRequirePayment ?? false,
-                    delegate (bool enabled)
-                    {
-                        if (settings == null) settings = new();
-                        settings.EndGearHelpersRequirePayment = enabled;
-                        builder.Rebuild();
-                    }
-                )
-            ).Tooltip("Enable End Gear Helper Cost", $"Will cost 1 minute of AI Brake Crew & Caboose Crew time per car in the consist when the new inspector buttons are utilized.\n\n1.5x multiplier penalty to AI Brake Crew cost if no sufficiently crewed caboose nearby.\n\nCaboose starts reloading `Crew Hours` at any Team or Repair track (no waybill), after being stationary for 30 seconds.");
-        });
-    }
-
-    private void WebhooksListUISection(ref UIPanelBuilder builder)
+    private void WebhooksListUISection(UIPanelBuilder builder)
     {
         builder.AddSection("Webhooks List", delegate (UIPanelBuilder builder)
         {

--- a/updates.json
+++ b/updates.json
@@ -1,0 +1,12 @@
+{
+  "RMROC451.TweaksAndThings": {
+    "version": "1.0.0",
+    "changelog": [
+      {
+        "version": "*",
+        "date": "2024-07-26T14:31:49.0948925Z",
+        "desc": "https://github.com/rmroc451/TweaksAndThings/releases"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Closes #27 
   - fix issue with last car end gear issue detection
- Closes #28 
   - add hotbox icon to tag update info
- Closes #25 
   - adding follow to car context menu
- Closes #24 
   - adding consist info to non motive power cars, that have a caboose when `Caboose Use` mod setting is enabled.
- Closes #29 
- Closes #30 
   - Allow caboose setting to require that a caboose is present in the consist to use the AI Engineer's AutoOiler & - AutoHotboxSpotter.